### PR TITLE
Use the Tribe__Tickets_Plus__Commerce__WooCommerce__Main class to extend to prevent fatal errors

### DIFF
--- a/src/Attendee_Helper.php
+++ b/src/Attendee_Helper.php
@@ -3,12 +3,12 @@
 namespace Tribe\Extensions\ET_Woo_Order_Details;
 
 use ReflectionClass;
-use Tribe__Tickets__Tickets;
+use Tribe__Tickets_Plus__Commerce__WooCommerce__Main;
 
 /**
  * Extend class from Event Tickets to expose non-public methods to this extension.
  */
-class Attendee_Helper extends Tribe__Tickets__Tickets {
+class Attendee_Helper extends Tribe__Tickets_Plus__Commerce__WooCommerce__Main {
 
 	/**
 	 * Returns the meta key used to link attendees with orders.


### PR DESCRIPTION
This class is not a real ticket/commerce provider. It should extend the WC class which helps give it the correct object in some areas of the code when it's set up and called through the normal modules registration.

Needs a changelog and ticket too